### PR TITLE
Fix attribute quotation mark wrapping

### DIFF
--- a/views/appointments/edit.pug
+++ b/views/appointments/edit.pug
@@ -7,7 +7,7 @@ block styles
 block content
   h2 Create New Appointment
 
-  form#formAppointment.form-horizontal.col-lg-5(name='formAppointment', method='POST', action='/appointments/" + appointment.id + "/edit', data-parsley-validate='')
+  form#formAppointment.form-horizontal.col-lg-5(name='formAppointment', method='POST', action='/appointments/' + appointment.id + '/edit', data-parsley-validate='')
     include _form
 
     .form-group


### PR DESCRIPTION
Two strings in line 10 were wrapped by a single quotation mark at the beginning and a double quotation mark at the end. This was preventing appointment.id from rendering, which caused an error when saving appointment edits.