### PR TITLE
Update config.js to use dotenv-safe config() function

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('dotenv-safe').load();
+require('dotenv-safe').config();
 
 const cfg = {};
 


### PR DESCRIPTION
As of the [dotenv 7.0.0 release](https://github.com/motdotla/dotenv/blob/master/CHANGELOG.md#700---2019-03-12) (and thus as of [dotenv-safe 8.1.0](https://github.com/rolodato/dotenv-safe/blob/master/CHANGELOG.markdown#810---2019-08-20)), the `load()` function is no longer supported, and `config()` must be used instead.